### PR TITLE
Implement city search form with validation and routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mausam",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.0",
         "@angular/compiler": "^21.2.0",
         "@angular/core": "^21.2.0",
@@ -421,6 +422,22 @@
         "vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "21.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.9.tgz",
+      "integrity": "sha512-0JXsr8f7xjV2815esTSq4+zGqWMa0CyNT/DV1F7lYS6qkYXcFdYUzGcd/WjNL05VKkajkSkWmTi6uyVsOpYdGA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^8.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0 || ^22.0.0",
+        "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -6845,7 +6862,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^8.0.0"
@@ -6899,7 +6915,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "packageManager": "npm@10.9.4",
   "dependencies": {
+    "@angular/cdk": "^21.2.9",
     "@angular/common": "^21.2.0",
     "@angular/compiler": "^21.2.0",
     "@angular/core": "^21.2.0",

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,0 +1,10 @@
+html,
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    Arial,
+    sans-serif;
+}

--- a/src/app/pages/search-page/search-page.css
+++ b/src/app/pages/search-page/search-page.css
@@ -1,0 +1,43 @@
+.page-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.card {
+  display: block;
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.75em;
+  padding: 1em;
+  background: transparent;
+  border: 0.0625em solid var(--border, #ccc);
+}
+
+.input-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+input {
+  flex: 1;
+  padding: 0.5em 0.75em;
+  border: 1px solid #ccc;
+  border-radius: 100em;
+}
+
+button {
+  padding: 0.485867em 1em;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 100em;
+  cursor: pointer;
+}
+
+.error {
+  color: #dc2626;
+  font-size: 0.85rem;
+  margin-top: 0.4rem;
+}

--- a/src/app/pages/search-page/search-page.html
+++ b/src/app/pages/search-page/search-page.html
@@ -3,11 +3,18 @@
     <h1>Mausam</h1>
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <div class="input-row">
-        <input formControlName="city" placeholder="Enter a city..." cdkFocusInitial />
+        <label for="city">City</label>
+        <input
+          id="city"
+          formControlName="city"
+          placeholder="Enter a city..."
+          autofocus
+          [attr.aria-describedby]="cityControl.invalid && cityControl.touched ? 'city-error' : null"
+        />
         <button type="submit">Get Outfit</button>
       </div>
       @if (cityControl.invalid && cityControl.touched) {
-      <p class="error">Please enter a city name.</p>
+      <p id="city-error" class="error">Please enter a city name.</p>
       }
     </form>
   </div>

--- a/src/app/pages/search-page/search-page.html
+++ b/src/app/pages/search-page/search-page.html
@@ -1,1 +1,14 @@
-<p>search-page works!</p>
+<div class="page-wrapper">
+  <div class="card">
+    <h1>Mausam</h1>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <div class="input-row">
+        <input formControlName="city" placeholder="Enter a city..." cdkFocusInitial />
+        <button type="submit">Get Outfit</button>
+      </div>
+      @if (cityControl.invalid && cityControl.touched) {
+      <p class="error">Please enter a city name.</p>
+      }
+    </form>
+  </div>
+</div>

--- a/src/app/pages/search-page/search-page.ts
+++ b/src/app/pages/search-page/search-page.ts
@@ -1,9 +1,42 @@
-import { Component } from '@angular/core';
+import { A11yModule } from '@angular/cdk/a11y';
+import { Component, inject } from '@angular/core';
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-search-page',
-  imports: [],
+  imports: [ReactiveFormsModule, A11yModule],
   templateUrl: './search-page.html',
   styleUrl: './search-page.css',
 })
-export class SearchPage {}
+export class SearchPage {
+  fb = inject(FormBuilder);
+  router = inject(Router);
+
+  form = this.fb.group({
+    city: ['', [Validators.required, nonBlank]],
+  });
+
+  get cityControl() {
+    return this.form.get('city')!;
+  }
+
+  onSubmit() {
+    this.form.markAllAsTouched();
+
+    if (this.form.invalid) return;
+
+    const city = this.cityControl.value!.trim();
+    this.router.navigate(['/outfit', city]);
+  }
+}
+
+function nonBlank(control: AbstractControl): ValidationErrors | null {
+  return control.value?.trim().length > 0 ? null : { required: true };
+}

--- a/src/app/pages/search-page/search-page.ts
+++ b/src/app/pages/search-page/search-page.ts
@@ -1,4 +1,3 @@
-import { A11yModule } from '@angular/cdk/a11y';
 import { Component, inject } from '@angular/core';
 import {
   AbstractControl,
@@ -11,7 +10,7 @@ import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-search-page',
-  imports: [ReactiveFormsModule, A11yModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './search-page.html',
   styleUrl: './search-page.css',
 })


### PR DESCRIPTION
Implements the `SearchPage` with a reactive city search form that validates input and navigates to the outfit results route. Adds `@angular/cdk` for accessibility support (`cdkFocusInitial` auto-focuses the input on load). Sets the weather API key in both environment files and applies baseline global and page-level styles.

## Changes

- Built `SearchPage` component with a reactive form using `FormBuilder`, `Validators.required`, and a custom `nonBlank` validator
- Wired form submission in `SearchPage` to navigate to `/outfit/:city` via `Router`
- Added `A11yModule` (`cdkFocusInitial`) to auto-focus the city input on page load
- Styled `search-page` with a centered card layout, pill-shaped input/button, and inline error message
- Added `@angular/cdk` dependency to `package.json` and `package-lock.json`
- Applied system font stack globally in `app.css`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now access a dedicated search page with a form to search for outfits by city name. The form includes real-time validation that displays error messages if input is invalid or empty.

* **Style**
  * Updated default typography across the app to use system fonts for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->