### PR TITLE
Implement weather result page with loading and error states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 .env
 .env.*
 *.secret
+public/config.json

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,9 +1,23 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
+import {
+  ApplicationConfig,
+  APP_INITIALIZER,
+  provideBrowserGlobalErrorListeners,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
-
-import { routes } from './app.routes';
 import { provideHttpClient } from '@angular/common/http';
+import { routes } from './app.routes';
+import { ConfigService } from './core/services/config.service';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideBrowserGlobalErrorListeners(), provideRouter(routes), provideHttpClient()],
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideRouter(routes),
+    provideHttpClient(),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (cfg: ConfigService) => () => cfg.load(),
+      deps: [ConfigService],
+      multi: true,
+    },
+  ],
 };

--- a/src/app/components/weather-card/weather-card.html
+++ b/src/app/components/weather-card/weather-card.html
@@ -1,0 +1,6 @@
+<div>
+  <p>Temperature: {{ weather.temperature }}</p>
+  <p>Condition: {{ weather.condition }}</p>
+  <p>Humidity: {{ weather.humidity }}</p>
+  <p>Wind Speed: {{ weather.windSpeed }}</p>
+</div>

--- a/src/app/components/weather-card/weather-card.spec.ts
+++ b/src/app/components/weather-card/weather-card.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WeatherCard } from './weather-card';
+import { WeatherData } from '../../models/weather.model';
+
+describe('WeatherCard', () => {
+  let component: WeatherCard;
+  let fixture: ComponentFixture<WeatherCard>;
+
+  const mockWeather: WeatherData = {
+    temperature: 22,
+    condition: 'Sunny',
+    humidity: 60,
+    windSpeed: 15,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WeatherCard],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WeatherCard);
+    component = fixture.componentInstance;
+
+    // Set required @Input before detectChanges — omitting causes runtime error
+    fixture.componentRef.setInput('weather', mockWeather);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('initial render', () => {
+    let paragraphs: NodeListOf<HTMLParagraphElement>;
+
+    beforeEach(() => {
+      paragraphs = fixture.nativeElement.querySelectorAll('p');
+    });
+
+    it('should render exactly 4 data paragraphs', () => {
+      expect(paragraphs.length).toBe(4);
+    });
+
+    it('should render the temperature', () => {
+      expect(paragraphs[0].textContent).toContain('Temperature: 22');
+    });
+
+    it('should render the condition', () => {
+      expect(paragraphs[1].textContent).toContain('Condition: Sunny');
+    });
+
+    it('should render the humidity', () => {
+      expect(paragraphs[2].textContent).toContain('Humidity: 60');
+    });
+
+    it('should render the wind speed', () => {
+      expect(paragraphs[3].textContent).toContain('Wind Speed: 15');
+    });
+  });
+
+  it('should display all weather fields in the template', () => {
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Temperature: 22');
+    expect(text).toContain('Condition: Sunny');
+    expect(text).toContain('Humidity: 60');
+    expect(text).toContain('Wind Speed: 15');
+  });
+
+  it('should update DOM when weather input changes', () => {
+    const updatedWeather: WeatherData = {
+      temperature: 5,
+      condition: 'Snowy',
+      humidity: 85,
+      windSpeed: 40,
+    };
+
+    fixture.componentRef.setInput('weather', updatedWeather);
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Temperature: 5');
+    expect(text).toContain('Condition: Snowy');
+    expect(text).toContain('Humidity: 85');
+    expect(text).toContain('Wind Speed: 40');
+    expect(text).not.toContain('Sunny');
+    expect(text).not.toContain('Temperature: 22');
+  });
+});

--- a/src/app/components/weather-card/weather-card.ts
+++ b/src/app/components/weather-card/weather-card.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+import { WeatherData } from '../../models/weather.model';
+
+@Component({
+  selector: 'app-weather-card',
+  imports: [],
+  templateUrl: './weather-card.html',
+  styleUrl: './weather-card.css',
+})
+export class WeatherCard {
+  @Input({ required: true }) weather!: WeatherData;
+}

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -6,7 +6,14 @@ export class ConfigService {
 
   load(): Promise<void> {
     return fetch('/config.json')
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) {
+          return Promise.reject(
+            new Error(`Failed to load config.json: ${r.status} ${r.statusText}`),
+          );
+        }
+        return r.json();
+      })
       .then((json) => {
         this.config = json;
       });

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ConfigService {
+  private config: Record<string, string> = {};
+
+  load(): Promise<void> {
+    return fetch('/config.json')
+      .then((r) => r.json())
+      .then((json) => {
+        this.config = json;
+      });
+  }
+
+  get(key: string): string {
+    return this.config[key];
+  }
+}

--- a/src/app/pages/result-page/result-page.css
+++ b/src/app/pages/result-page/result-page.css
@@ -1,0 +1,46 @@
+.page-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  width: 3rem;
+  height: 3rem;
+  border: 0.25rem solid var(--border, #ccc);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+app-weather-card {
+  display: block;
+  width: 100%;
+  max-width: 24rem;
+}
+
+.card {
+  border: 0.0625em solid var(--border, #ccc);
+  border-radius: 0.75em;
+  padding: 1.5em;
+}
+
+.error {
+  color: #dc2626;
+  text-align: center;
+}
+
+a[routerLink] {
+  font-size: 0.875rem;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/src/app/pages/result-page/result-page.html
+++ b/src/app/pages/result-page/result-page.html
@@ -1,9 +1,9 @@
 <div class="page-wrapper">
   @if (loading()) {
   <div class="spinner"></div>
-  } @if (error()) {
+  } @else if (error()) {
   <p class="error">{{ error() }}</p>
-  } @if(weather()) {
+  } @else if(weather()) {
   <app-weather-card [weather]="weather()!"></app-weather-card>
   }
   <a routerLink="/">Search again</a>

--- a/src/app/pages/result-page/result-page.html
+++ b/src/app/pages/result-page/result-page.html
@@ -1,1 +1,10 @@
-<p>result-page works!</p>
+<div class="page-wrapper">
+  @if (loading()) {
+  <div class="spinner"></div>
+  } @if (error()) {
+  <p class="error">{{ error() }}</p>
+  } @if(weather()) {
+  <app-weather-card [weather]="weather()!"></app-weather-card>
+  }
+  <a routerLink="/">Search again</a>
+</div>

--- a/src/app/pages/result-page/result-page.ts
+++ b/src/app/pages/result-page/result-page.ts
@@ -24,8 +24,13 @@ export class ResultPage implements OnInit {
 
   ngOnInit(): void {
     const city = this.route.snapshot.paramMap.get('city');
+    if (!city) {
+      this.error.set('No city specified.');
+      this.loading.set(false);
+      return;
+    }
     this.weatherService
-      .getWeather(city!)
+      .getWeather(city)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {

--- a/src/app/pages/result-page/result-page.ts
+++ b/src/app/pages/result-page/result-page.ts
@@ -1,9 +1,41 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { WeatherService } from '../../services/weather.service';
+import { CityNotFoundError, WeatherData } from '../../models/weather.model';
+import { WeatherCard } from '../../components/weather-card/weather-card';
 
 @Component({
   selector: 'app-result-page',
-  imports: [],
+  imports: [WeatherCard, RouterLink],
   templateUrl: './result-page.html',
   styleUrl: './result-page.css',
 })
-export class ResultPage {}
+export class ResultPage {
+  weather = signal<WeatherData | null>(null);
+  loading = signal(true);
+  error = signal<string | null>(null);
+
+  constructor(
+    private route: ActivatedRoute,
+    private weatherService: WeatherService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    const city = this.route.snapshot.paramMap.get('city');
+    this.weatherService.getWeather(city!).subscribe({
+      next: (data) => {
+        this.weather.set(data);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        if (err instanceof CityNotFoundError) {
+          this.error.set("We couldn't find that city. Try a different spelling.");
+        } else {
+          this.error.set('Something went wrong. Please try again.');
+        }
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/src/app/pages/result-page/result-page.ts
+++ b/src/app/pages/result-page/result-page.ts
@@ -1,8 +1,9 @@
-import { Component, inject, signal } from '@angular/core';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Component, DestroyRef, OnInit, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { WeatherService } from '../../services/weather.service';
 import { CityNotFoundError, WeatherData } from '../../models/weather.model';
 import { WeatherCard } from '../../components/weather-card/weather-card';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-result-page',
@@ -10,7 +11,7 @@ import { WeatherCard } from '../../components/weather-card/weather-card';
   templateUrl: './result-page.html',
   styleUrl: './result-page.css',
 })
-export class ResultPage {
+export class ResultPage implements OnInit {
   weather = signal<WeatherData | null>(null);
   loading = signal(true);
   error = signal<string | null>(null);
@@ -18,24 +19,27 @@ export class ResultPage {
   constructor(
     private route: ActivatedRoute,
     private weatherService: WeatherService,
-    private router: Router,
+    private destroyRef: DestroyRef,
   ) {}
 
   ngOnInit(): void {
     const city = this.route.snapshot.paramMap.get('city');
-    this.weatherService.getWeather(city!).subscribe({
-      next: (data) => {
-        this.weather.set(data);
-        this.loading.set(false);
-      },
-      error: (err) => {
-        if (err instanceof CityNotFoundError) {
-          this.error.set("We couldn't find that city. Try a different spelling.");
-        } else {
-          this.error.set('Something went wrong. Please try again.');
-        }
-        this.loading.set(false);
-      },
-    });
+    this.weatherService
+      .getWeather(city!)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.weather.set(data);
+          this.loading.set(false);
+        },
+        error: (err) => {
+          if (err instanceof CityNotFoundError) {
+            this.error.set("We couldn't find that city. Try a different spelling.");
+          } else {
+            this.error.set('Something went wrong. Please try again.');
+          }
+          this.loading.set(false);
+        },
+      });
   }
 }

--- a/src/app/services/weather.service.ts
+++ b/src/app/services/weather.service.ts
@@ -2,17 +2,18 @@ import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http'
 import { inject, Injectable } from '@angular/core';
 import { catchError, map, Observable, throwError } from 'rxjs';
 import { CityNotFoundError, WeatherData } from '../models/weather.model';
-import { environment } from '../../environments/environment';
+import { ConfigService } from '../core/services/config.service';
 
 @Injectable({ providedIn: 'root' })
 export class WeatherService {
   private http = inject(HttpClient);
+  private configService = inject(ConfigService);
   private readonly BASE_URL = 'https://api.openweathermap.org/data/2.5/weather';
 
   getWeather(city: string): Observable<WeatherData> {
     const params = new HttpParams()
       .set('q', city)
-      .set('appid', environment.weatherApiKey)
+      .set('appid', this.configService.get('weatherApiKey'))
       .set('units', 'metric');
 
     return this.http.get<OWMResponse>(this.BASE_URL, { params }).pipe(

--- a/src/app/services/weather.spec.ts
+++ b/src/app/services/weather.spec.ts
@@ -27,7 +27,7 @@ describe('WeatherService', () => {
     });
 
     http
-      .expectOne((r) => r.url.includes('London'))
+      .expectOne((r) => r.urlWithParams.includes('London'))
       .flush({
         main: { temp: 20, humidity: 60 },
         weather: [{ description: 'clear sky' }],
@@ -41,7 +41,7 @@ describe('WeatherService', () => {
     });
 
     http
-      .expectOne((r) => r.url.includes('zzzzz'))
+      .expectOne((r) => r.urlWithParams.includes('zzzzz'))
       .flush(null, { status: 404, statusText: 'Not Found' });
   });
 });

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,3 +1,3 @@
 export const environment = {
-  weatherApiKey: '',
+  weatherApiKey: 'f3307e1c182f809bf661b55b1a7409e9',
 };

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,3 +1,1 @@
-export const environment = {
-  weatherApiKey: 'f3307e1c182f809bf661b55b1a7409e9',
-};
+export const environment = {};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,3 @@
 export const environment = {
-  weatherApiKey: '',
+  weatherApiKey: 'f3307e1c182f809bf661b55b1a7409e9',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,1 @@
-export const environment = {
-  weatherApiKey: 'f3307e1c182f809bf661b55b1a7409e9',
-};
+export const environment = {};


### PR DESCRIPTION
Implements the `ResultPage` component to display weather results after a city search. The page reads the city from the route params, calls `WeatherService`, and renders the `WeatherCard` on success or a user-friendly error message on failure. A spinner is shown while the request is in flight.

## Changes

- Implemented `ResultPage` with signals for `weather`, `loading`, and `error` state driven by `WeatherService`
- Added template with spinner, error message, `WeatherCard`, and a "Search again" back-link
- Styled `result-page.css` with spinner animation, card layout, error color, and link styles
- Fixed `weather.spec.ts` to match on `urlWithParams` instead of `url` so query-string params are included in test assertions
- Added `weatherApiKey` to both `environment.ts` and `environment.development.ts` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weather card displaying temperature, condition, humidity, and wind speed
  * Result page now shows a loading spinner, error messages, and a "Search again" link

* **Tests**
  * Added unit tests for the weather card component
  * Updated weather service tests for request matching

* **Chores**
  * App now loads runtime configuration for the weather API and initializes on startup
  * Added spinner and page layout styles; ignored public/config.json in VCS
<!-- end of auto-generated comment: release notes by coderabbit.ai -->