### PR TITLE
Add OutfitService for recommendations and fix wind speed conversion

### DIFF
--- a/src/app/services/outfit.service.ts
+++ b/src/app/services/outfit.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { WeatherData } from '../models/weather.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OutfitService {
+  getRecommendations(weather: WeatherData): string[] {
+    const items = [
+      ...this.getBaseItems(weather.temperature),
+      ...this.getRainItems(weather.condition),
+      ...this.getSnowItems(weather.condition),
+      ...this.getWindItems(weather.windSpeed),
+    ];
+    return Array.from(new Set(items));
+  }
+
+  private getBaseItems(temp: number): string[] {
+    if (temp < 0) return ['heavy coat', 'thermal layers', 'gloves', 'hat'];
+    if (temp < 10) return ['winter coat', 'scarf', 'warm shoes'];
+    if (temp < 18) return ['light jacket', 'hoodie', 'jeans'];
+    if (temp < 25) return ['t-shirt', 'light trousers'];
+    return ['shorts', 't-shirt', 'sunglasses'];
+  }
+
+  private getRainItems(condition: string): string[] {
+    return condition.toLowerCase().includes('rain') ? ['umbrella', 'raincoat'] : [];
+  }
+
+  private getSnowItems(condition: string): string[] {
+    return condition.toLowerCase().includes('snow') ? ['boots', 'gloves'] : [];
+  }
+
+  private getWindItems(windSpeed: number): string[] {
+    return windSpeed > 30 ? ['windbreaker'] : [];
+  }
+}

--- a/src/app/services/outfit.spec.ts
+++ b/src/app/services/outfit.spec.ts
@@ -1,0 +1,180 @@
+import { TestBed } from '@angular/core/testing';
+import { OutfitService } from './outfit.service';
+import { WeatherData } from '../models/weather.model';
+
+describe('OutfitService', () => {
+  let service: OutfitService;
+
+  const base = (overrides: Partial<WeatherData> = {}): WeatherData => ({
+    temperature: 20,
+    condition: 'clear sky',
+    windSpeed: 10,
+    humidity: 50,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(OutfitService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  // ── Temperature tiers ─────────────────────────────────────────────────────
+
+  describe('temperature tiers', () => {
+    it('below 0°C -> heavy coat tier', () => {
+      const items = service.getRecommendations(base({ temperature: -5 }));
+      expect(items).toContain('heavy coat');
+      expect(items).toContain('thermal layers');
+      expect(items).toContain('gloves');
+      expect(items).toContain('hat');
+    });
+
+    it('exactly 0°C -> winter coat tier (not heavy coat)', () => {
+      const items = service.getRecommendations(base({ temperature: 0 }));
+      expect(items).toContain('winter coat');
+      expect(items).not.toContain('heavy coat');
+    });
+
+    it('0–10°C -> winter coat tier', () => {
+      const items = service.getRecommendations(base({ temperature: 5 }));
+      expect(items).toContain('winter coat');
+      expect(items).toContain('scarf');
+      expect(items).toContain('warm shoes');
+    });
+
+    it('exactly 10°C -> light jacket tier', () => {
+      const items = service.getRecommendations(base({ temperature: 10 }));
+      expect(items).toContain('light jacket');
+      expect(items).not.toContain('winter coat');
+    });
+
+    it('10–18°C -> light jacket + hoodie + jeans', () => {
+      const items = service.getRecommendations(base({ temperature: 14 }));
+      expect(items).toContain('light jacket');
+      expect(items).toContain('hoodie');
+      expect(items).toContain('jeans');
+    });
+
+    it('exactly 18°C -> t-shirt tier', () => {
+      const items = service.getRecommendations(base({ temperature: 18 }));
+      expect(items).toContain('t-shirt');
+      expect(items).not.toContain('light jacket');
+    });
+
+    it('18–25°C -> t-shirt + light trousers', () => {
+      const items = service.getRecommendations(base({ temperature: 22 }));
+      expect(items).toContain('t-shirt');
+      expect(items).toContain('light trousers');
+    });
+
+    it('exactly 25°C -> shorts tier', () => {
+      const items = service.getRecommendations(base({ temperature: 25 }));
+      expect(items).toContain('shorts');
+      expect(items).not.toContain('light trousers');
+    });
+
+    it('above 25°C -> shorts + t-shirt + sunglasses', () => {
+      const items = service.getRecommendations(base({ temperature: 30 }));
+      expect(items).toContain('shorts');
+      expect(items).toContain('t-shirt');
+      expect(items).toContain('sunglasses');
+    });
+  });
+
+  // ── Condition appends ─────────────────────────────────────────────────────
+
+  describe('rain condition', () => {
+    it('appends umbrella + raincoat on "light rain"', () => {
+      const items = service.getRecommendations(base({ condition: 'light rain' }));
+      expect(items).toContain('umbrella');
+      expect(items).toContain('raincoat');
+    });
+
+    it('matches rain case-insensitively', () => {
+      const items = service.getRecommendations(base({ condition: 'Heavy Rain' }));
+      expect(items).toContain('umbrella');
+    });
+
+    it('no rain items on clear sky', () => {
+      const items = service.getRecommendations(base({ condition: 'clear sky' }));
+      expect(items).not.toContain('umbrella');
+      expect(items).not.toContain('raincoat');
+    });
+  });
+
+  describe('snow condition', () => {
+    it('appends boots + gloves on "light snow"', () => {
+      const items = service.getRecommendations(base({ condition: 'light snow' }));
+      expect(items).toContain('boots');
+      expect(items).toContain('gloves');
+    });
+
+    it('matches snow case-insensitively', () => {
+      const items = service.getRecommendations(base({ condition: 'Heavy Snow' }));
+      expect(items).toContain('boots');
+    });
+  });
+
+  describe('wind', () => {
+    it('appends windbreaker when windSpeed > 30', () => {
+      const items = service.getRecommendations(base({ windSpeed: 31 }));
+      expect(items).toContain('windbreaker');
+    });
+
+    it('no windbreaker at exactly 30', () => {
+      const items = service.getRecommendations(base({ windSpeed: 30 }));
+      expect(items).not.toContain('windbreaker');
+    });
+
+    it('no windbreaker below 30', () => {
+      const items = service.getRecommendations(base({ windSpeed: 20 }));
+      expect(items).not.toContain('windbreaker');
+    });
+  });
+
+  // ── Combined conditions ───────────────────────────────────────────────────
+
+  describe('combined conditions', () => {
+    it('rain + snow both append independently', () => {
+      const items = service.getRecommendations(base({ condition: 'freezing rain and snow' }));
+      expect(items).toContain('umbrella');
+      expect(items).toContain('raincoat');
+      expect(items).toContain('boots');
+      expect(items).toContain('gloves');
+    });
+
+    it('sub-zero + snow -> gloves deduplicated (appears once)', () => {
+      const items = service.getRecommendations(base({ temperature: -5, condition: 'light snow' }));
+      expect(items.filter((i) => i === 'gloves').length).toBe(1);
+    });
+
+    it('all conditions active -> all extra items present', () => {
+      const items = service.getRecommendations({
+        temperature: -5,
+        condition: 'heavy snow and rain',
+        windSpeed: 50,
+        humidity: 90,
+      });
+      expect(items).toContain('heavy coat');
+      expect(items).toContain('umbrella');
+      expect(items).toContain('boots');
+      expect(items).toContain('windbreaker');
+    });
+  });
+
+  // ── Deduplication ─────────────────────────────────────────────────────────
+
+  describe('deduplication', () => {
+    it('returns no duplicate items', () => {
+      const items = service.getRecommendations(
+        base({ temperature: -5, condition: 'snow', windSpeed: 50 }),
+      );
+      const unique = new Set(items);
+      expect(items.length).toBe(unique.size);
+    });
+  });
+});

--- a/src/app/services/weather.service.ts
+++ b/src/app/services/weather.service.ts
@@ -20,7 +20,7 @@ export class WeatherService {
       map((res) => ({
         temperature: res.main.temp,
         condition: res.weather[0].description,
-        windSpeed: res.wind.speed,
+        windSpeed: res.wind.speed * 3.6,
         humidity: res.main.humidity,
       })),
       catchError((err: HttpErrorResponse) => {

--- a/src/app/services/weather.spec.ts
+++ b/src/app/services/weather.spec.ts
@@ -22,7 +22,7 @@ describe('WeatherService', () => {
     service.getWeather('London').subscribe((data) => {
       expect(data.temperature).toBe(20);
       expect(data.condition).toBe('clear sky');
-      expect(data.windSpeed).toBe(5.1);
+      expect(data.windSpeed).toBe(18.36);
       expect(data.humidity).toBe(60);
     });
 


### PR DESCRIPTION
Implements `OutfitService` with rule-based outfit recommendations based on temperature ranges, weather condition, and wind speed. Also fixes a unit mismatch in `WeatherService` where wind speed was returned in m/s instead of km/h — the outfit rules require km/h, so the conversion (`× 3.6`) is applied at the mapping layer.

## Changes

- Created `OutfitService` with `getRecommendations(weather)` returning a deduplicated `string[]` of clothing items
- Implemented five temperature tiers (<0, 0–10, 10–18, 18–25, >25°C) in `getBaseItems()`
- Added condition-based appends for rain, snow, and high wind in `getRainItems()`, `getSnowItems()`, `getWindItems()`
- Applied `Array.from(new Set(...))` deduplication to handle overlapping items (e.g. gloves from both sub-zero tier and snow condition)
- Fixed `WeatherService` to convert OWM wind speed from m/s to km/h (`× 3.6`) before returning `WeatherData`
- Added `outfit.spec.ts` covering all temperature tier boundaries, condition appends, combined conditions, and deduplication
- Updated `weather.spec.ts` to expect `18.36` km/h instead of raw `5.1` m/s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced outfit recommendations that suggest appropriate clothing items based on current weather conditions, including temperature ranges, precipitation, and wind speed.

* **Improvements**
  * Enhanced weather data processing to ensure recommendations are accurate and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->