### PR TITLE
Add temperature unit toggle with TemperaturePipe and SettingsService

### DIFF
--- a/src/app/components/weather-card/weather-card.html
+++ b/src/app/components/weather-card/weather-card.html
@@ -1,6 +1,6 @@
 <div class="card">
-  <p>Temperature: {{ weather().temperature }}</p>
+  <p>Temperature: {{ weather().temperature | temperature: unit() }}</p>
   <p>Condition: {{ weather().condition }}</p>
-  <p>Humidity: {{ weather().humidity }}</p>
-  <p>Wind Speed: {{ weather().windSpeed }}</p>
+  <p>Humidity: {{ weather().humidity }}%</p>
+  <p>Wind Speed: {{ weather().windSpeed }} km/h</p>
 </div>

--- a/src/app/components/weather-card/weather-card.html
+++ b/src/app/components/weather-card/weather-card.html
@@ -2,5 +2,5 @@
   <p>Temperature: {{ weather().temperature | temperature: unit() }}</p>
   <p>Condition: {{ weather().condition }}</p>
   <p>Humidity: {{ weather().humidity }}%</p>
-  <p>Wind Speed: {{ weather().windSpeed }} km/h</p>
+  <p>Wind Speed: {{ weather().windSpeed | windSpeed: unit() }}</p>
 </div>

--- a/src/app/components/weather-card/weather-card.spec.ts
+++ b/src/app/components/weather-card/weather-card.spec.ts
@@ -22,8 +22,8 @@ describe('WeatherCard', () => {
     fixture = TestBed.createComponent(WeatherCard);
     component = fixture.componentInstance;
 
-    // Set required @Input before detectChanges — omitting causes runtime error
     fixture.componentRef.setInput('weather', mockWeather);
+    fixture.componentRef.setInput('unit', 'metric');
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -50,7 +50,7 @@ describe('WeatherCard', () => {
     });
 
     it('should render the temperature', () => {
-      expect(paragraphs[0].textContent).toContain('Temperature: 22');
+      expect(paragraphs[0].textContent).toContain('Temperature: 22.0°C');
     });
 
     it('should render the condition', () => {
@@ -62,16 +62,16 @@ describe('WeatherCard', () => {
     });
 
     it('should render the wind speed', () => {
-      expect(paragraphs[3].textContent).toContain('Wind Speed: 15');
+      expect(paragraphs[3].textContent).toContain('Wind Speed: 15.0 km/h');
     });
   });
 
   it('should display all weather fields in the template', () => {
     const text = fixture.nativeElement.textContent as string;
-    expect(text).toContain('Temperature: 22');
+    expect(text).toContain('Temperature: 22.0°C');
     expect(text).toContain('Condition: Sunny');
     expect(text).toContain('Humidity: 60');
-    expect(text).toContain('Wind Speed: 15');
+    expect(text).toContain('Wind Speed: 15.0 km/h');
   });
 
   it('should update DOM when weather input changes', () => {
@@ -86,11 +86,28 @@ describe('WeatherCard', () => {
     fixture.detectChanges();
 
     const text = fixture.nativeElement.textContent as string;
-    expect(text).toContain('Temperature: 5');
+    expect(text).toContain('Temperature: 5.0°C');
     expect(text).toContain('Condition: Snowy');
     expect(text).toContain('Humidity: 85');
-    expect(text).toContain('Wind Speed: 40');
+    expect(text).toContain('Wind Speed: 40.0 km/h');
     expect(text).not.toContain('Sunny');
     expect(text).not.toContain('Temperature: 22');
+  });
+
+  describe('imperial unit', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('unit', 'imperial');
+      fixture.detectChanges();
+    });
+
+    it('should convert temperature to °F', () => {
+      const text = fixture.nativeElement.textContent as string;
+      expect(text).toContain('71.6°F');
+    });
+
+    it('should convert wind speed to mph', () => {
+      const text = fixture.nativeElement.textContent as string;
+      expect(text).toContain('9.3 mph');
+    });
   });
 });

--- a/src/app/components/weather-card/weather-card.ts
+++ b/src/app/components/weather-card/weather-card.ts
@@ -1,12 +1,14 @@
 import { Component, input, Input } from '@angular/core';
 import { WeatherData } from '../../models/weather.model';
+import { TemperaturePipe } from '../../pipes/temperature-pipe';
 
 @Component({
   selector: 'app-weather-card',
-  imports: [],
+  imports: [TemperaturePipe],
   templateUrl: './weather-card.html',
   styleUrl: './weather-card.css',
 })
 export class WeatherCard {
   weather = input.required<WeatherData>();
+  unit = input.required<'metric' | 'imperial'>();
 }

--- a/src/app/components/weather-card/weather-card.ts
+++ b/src/app/components/weather-card/weather-card.ts
@@ -1,10 +1,11 @@
 import { Component, input, Input } from '@angular/core';
 import { WeatherData } from '../../models/weather.model';
 import { TemperaturePipe } from '../../pipes/temperature-pipe';
+import { WindSpeedPipe } from '../../pipes/wind-speed-pipe';
 
 @Component({
   selector: 'app-weather-card',
-  imports: [TemperaturePipe],
+  imports: [TemperaturePipe, WindSpeedPipe],
   templateUrl: './weather-card.html',
   styleUrl: './weather-card.css',
 })

--- a/src/app/pages/result-page/result-page.html
+++ b/src/app/pages/result-page/result-page.html
@@ -6,7 +6,7 @@
   } @else if (weather()) {
   <app-weather-card [weather]="weather()!" [unit]="unit()" />
   <button (click)="settingsService.toggle()">
-    Switch to {{ unit() === 'metric' ? '°F' : '°C' }}
+    Switch to {{ unit() === 'metric' ? 'imperial (°F / mph)' : 'metric (°C / km/h)' }}
   </button>
   <app-outfit-card [items]="outfit()" />
   }

--- a/src/app/pages/result-page/result-page.html
+++ b/src/app/pages/result-page/result-page.html
@@ -4,7 +4,10 @@
   } @else if (error()) {
   <p class="error">{{ error() }}</p>
   } @else if (weather()) {
-  <app-weather-card [weather]="weather()!" />
+  <app-weather-card [weather]="weather()!" [unit]="unit()" />
+  <button (click)="settingsService.toggle()">
+    Switch to {{ unit() === 'metric' ? '°F' : '°C' }}
+  </button>
   <app-outfit-card [items]="outfit()" />
   }
   <a routerLink="/">Search again</a>

--- a/src/app/pages/result-page/result-page.ts
+++ b/src/app/pages/result-page/result-page.ts
@@ -1,4 +1,4 @@
-import { Component, computed, DestroyRef, OnInit, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { WeatherService } from '../../services/weather.service';
 import { CityNotFoundError, WeatherData } from '../../models/weather.model';
@@ -7,6 +7,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { OutfitCard } from '../../components/outfit-card/outfit-card';
 import { OutfitService } from '../../services/outfit.service';
 import { RecentSearchesService } from '../../services/recent-searches.service';
+import { SettingsService } from '../../services/settings.service';
 
 @Component({
   selector: 'app-result-page',
@@ -18,6 +19,8 @@ export class ResultPage implements OnInit {
   weather = signal<WeatherData | null>(null);
   loading = signal(true);
   error = signal<string | null>(null);
+  settingsService = inject(SettingsService);
+  unit = this.settingsService.unit;
 
   outfit = computed(() => {
     const w = this.weather();

--- a/src/app/pipes/temperature-pipe.spec.ts
+++ b/src/app/pipes/temperature-pipe.spec.ts
@@ -1,0 +1,8 @@
+import { TemperaturePipe } from './temperature-pipe';
+
+describe('TemperaturePipe', () => {
+  it('create an instance', () => {
+    const pipe = new TemperaturePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/temperature-pipe.spec.ts
+++ b/src/app/pipes/temperature-pipe.spec.ts
@@ -1,8 +1,78 @@
 import { TemperaturePipe } from './temperature-pipe';
 
 describe('TemperaturePipe', () => {
-  it('create an instance', () => {
-    const pipe = new TemperaturePipe();
+  let pipe: TemperaturePipe;
+
+  beforeEach(() => {
+    pipe = new TemperaturePipe();
+  });
+
+  it('should create', () => {
     expect(pipe).toBeTruthy();
+  });
+
+  // ── Metric (default) ───────────────────────────────────────────────────────
+
+  describe('metric unit', () => {
+    it('returns value in °C with one decimal place', () => {
+      expect(pipe.transform(22, 'metric')).toBe('22.0°C');
+    });
+
+    it('handles 0°C', () => {
+      expect(pipe.transform(0, 'metric')).toBe('0.0°C');
+    });
+
+    it('handles negative temperatures', () => {
+      expect(pipe.transform(-10, 'metric')).toBe('-10.0°C');
+    });
+
+    it('rounds to one decimal place', () => {
+      expect(pipe.transform(22.55, 'metric')).toBe('22.6°C');
+    });
+  });
+
+  // ── Imperial ───────────────────────────────────────────────────────────────
+
+  describe('imperial unit', () => {
+    it('converts 0°C to 32.0°F', () => {
+      expect(pipe.transform(0, 'imperial')).toBe('32.0°F');
+    });
+
+    it('converts 100°C to 212.0°F', () => {
+      expect(pipe.transform(100, 'imperial')).toBe('212.0°F');
+    });
+
+    it('converts -40°C to -40.0°F (crossover point)', () => {
+      expect(pipe.transform(-40, 'imperial')).toBe('-40.0°F');
+    });
+
+    it('converts 22°C to 71.6°F', () => {
+      expect(pipe.transform(22, 'imperial')).toBe('71.6°F');
+    });
+
+    it('rounds to one decimal place', () => {
+      // 37°C = 98.6°F exactly
+      expect(pipe.transform(37, 'imperial')).toBe('98.6°F');
+    });
+  });
+
+  // ── Symbol ─────────────────────────────────────────────────────────────────
+
+  describe('output format', () => {
+    it('metric output ends with °C', () => {
+      expect(pipe.transform(20, 'metric')).toMatch(/°C$/);
+    });
+
+    it('imperial output ends with °F', () => {
+      expect(pipe.transform(20, 'imperial')).toMatch(/°F$/);
+    });
+
+    it('metric output does not contain °F', () => {
+      expect(pipe.transform(20, 'metric')).not.toContain('°F');
+    });
+
+    it('imperial output does not contain °C', () => {
+      expect(pipe.transform(20, 'imperial')).not.toContain('°C');
+    });
   });
 });

--- a/src/app/pipes/temperature-pipe.ts
+++ b/src/app/pipes/temperature-pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'temperature',
+  standalone: true,
+})
+export class TemperaturePipe implements PipeTransform {
+  transform(celsius: number, unit: 'metric' | 'imperial'): string {
+    if (unit === 'imperial') {
+      const fahrenheit = (celsius * 9) / 5 + 32;
+      return `${fahrenheit.toFixed(1)}°F`;
+    }
+    return `${celsius.toFixed(1)}°C`;
+  }
+}

--- a/src/app/pipes/wind-speed-pipe.spec.ts
+++ b/src/app/pipes/wind-speed-pipe.spec.ts
@@ -1,0 +1,68 @@
+import { WindSpeedPipe } from './wind-speed-pipe';
+
+describe('WindSpeedPipe', () => {
+  let pipe: WindSpeedPipe;
+
+  beforeEach(() => {
+    pipe = new WindSpeedPipe();
+  });
+
+  it('should create', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  // ── Metric ────────────────────────────────────────────────────────────────
+
+  describe('metric unit', () => {
+    it('returns value in km/h with 1 decimal place', () => {
+      expect(pipe.transform(10, 'metric')).toBe('10.0 km/h');
+    });
+
+    it('formats a whole number with .0', () => {
+      expect(pipe.transform(30, 'metric')).toBe('30.0 km/h');
+    });
+
+    it('formats a decimal value correctly', () => {
+      expect(pipe.transform(18.36, 'metric')).toBe('18.4 km/h');
+    });
+
+    it('handles zero', () => {
+      expect(pipe.transform(0, 'metric')).toBe('0.0 km/h');
+    });
+  });
+
+  // ── Imperial ──────────────────────────────────────────────────────────────
+
+  describe('imperial unit', () => {
+    it('converts km/h to mph and labels correctly', () => {
+      expect(pipe.transform(10, 'imperial')).toBe('6.2 mph');
+    });
+
+    it('rounds to 1 decimal place', () => {
+      // 100 km/h * 0.621371 = 62.1371 → 62.1
+      expect(pipe.transform(100, 'imperial')).toBe('62.1 mph');
+    });
+
+    it('handles zero', () => {
+      expect(pipe.transform(0, 'imperial')).toBe('0.0 mph');
+    });
+
+    it('uses the OWM-style wind speed from WeatherService (5.1 m/s → 18.36 km/h)', () => {
+      // WeatherService converts m/s * 3.6 before storing — this tests that
+      // the already-converted km/h value is what the pipe receives
+      expect(pipe.transform(18.36, 'imperial')).toBe('11.4 mph');
+    });
+  });
+
+  // ── Label format ──────────────────────────────────────────────────────────
+
+  describe('label format', () => {
+    it('metric output ends with " km/h"', () => {
+      expect(pipe.transform(20, 'metric')).toMatch(/ km\/h$/);
+    });
+
+    it('imperial output ends with " mph"', () => {
+      expect(pipe.transform(20, 'imperial')).toMatch(/ mph$/);
+    });
+  });
+});

--- a/src/app/pipes/wind-speed-pipe.ts
+++ b/src/app/pipes/wind-speed-pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'windSpeed',
+})
+export class WindSpeedPipe implements PipeTransform {
+  transform(kmh: number, unit: 'metric' | 'imperial'): string {
+    if (unit === 'imperial') {
+      return `${(kmh * 0.621371).toFixed(1)} mph`;
+    }
+    return `${kmh.toFixed(1)} km/h`;
+  }
+}

--- a/src/app/services/recent-searches.spec.ts
+++ b/src/app/services/recent-searches.spec.ts
@@ -1,0 +1,142 @@
+import { TestBed } from '@angular/core/testing';
+import { RecentSearchesService } from './recent-searches.service';
+
+describe('RecentSearchesService', () => {
+  let service: RecentSearchesService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RecentSearchesService);
+  });
+
+  afterEach(() => localStorage.clear());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  // ── getAll ────────────────────────────────────────────────────────────────
+
+  describe('getAll()', () => {
+    it('returns an empty signal when localStorage is empty', () => {
+      expect(service.getAll()()).toEqual([]);
+    });
+
+    it('returns a readonly signal (no set method exposed)', () => {
+      const sig = service.getAll();
+      expect(typeof (sig as any)['set']).toBe('undefined');
+    });
+
+    it('hydrates from localStorage on construction', () => {
+      localStorage.setItem('mausam_recent_searches', JSON.stringify(['Paris', 'Tokyo']));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+      const freshService = TestBed.inject(RecentSearchesService);
+      expect(freshService.getAll()()).toEqual(['Paris', 'Tokyo']);
+    });
+  });
+
+  // ── add ───────────────────────────────────────────────────────────────────
+
+  describe('add()', () => {
+    it('adds a city and reflects it in the signal', () => {
+      service.add('london');
+      expect(service.getAll()()).toContain('London');
+    });
+
+    it('prepends the new city to the front of the list', () => {
+      service.add('Paris');
+      service.add('Tokyo');
+      expect(service.getAll()()[0]).toBe('Tokyo');
+    });
+
+    it('persists to localStorage after add', () => {
+      service.add('Berlin');
+      const stored = JSON.parse(localStorage.getItem('mausam_recent_searches')!);
+      expect(stored).toContain('Berlin');
+    });
+
+    it('title-cases a lowercase city name', () => {
+      service.add('new york');
+      expect(service.getAll()()).toContain('New York');
+    });
+
+    it('title-cases an uppercase city name', () => {
+      service.add('LONDON');
+      expect(service.getAll()()).toContain('London');
+    });
+
+    it('title-cases a mixed-case city name', () => {
+      service.add('lOs AnGeLeS');
+      expect(service.getAll()()).toContain('Los Angeles');
+    });
+
+    it('trims leading and trailing whitespace', () => {
+      service.add('  Rome  ');
+      expect(service.getAll()()).toContain('Rome');
+    });
+  });
+
+  // ── deduplication ─────────────────────────────────────────────────────────
+
+  describe('deduplication', () => {
+    it('does not store a duplicate city', () => {
+      service.add('Paris');
+      service.add('Paris');
+      expect(
+        service
+          .getAll()()
+          .filter((c) => c === 'Paris').length,
+      ).toBe(1);
+    });
+
+    it('deduplicates case-insensitively', () => {
+      service.add('paris');
+      service.add('PARIS');
+      expect(
+        service
+          .getAll()()
+          .filter((c) => c === 'Paris').length,
+      ).toBe(1);
+    });
+
+    it('moves a re-added city to the front', () => {
+      service.add('Paris');
+      service.add('Tokyo');
+      service.add('paris');
+      const cities = service.getAll()();
+      expect(cities[0]).toBe('Paris');
+      expect(cities).not.toContain('paris');
+      expect(cities.filter((c) => c === 'Paris').length).toBe(1);
+    });
+  });
+
+  // ── localStorage resilience ───────────────────────────────────────────────
+
+  describe('localStorage resilience', () => {
+    it('returns empty array when localStorage contains invalid JSON', () => {
+      localStorage.setItem('mausam_recent_searches', 'not-json{{{');
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+      const freshService = TestBed.inject(RecentSearchesService);
+      expect(freshService.getAll()()).toEqual([]);
+    });
+
+    it('returns empty array when localStorage contains a non-array JSON value', () => {
+      localStorage.setItem('mausam_recent_searches', JSON.stringify({ city: 'Paris' }));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+      const freshService = TestBed.inject(RecentSearchesService);
+      expect(freshService.getAll()()).toEqual([]);
+    });
+
+    it('filters out non-string entries from a stored array', () => {
+      localStorage.setItem('mausam_recent_searches', JSON.stringify(['Paris', 42, null, 'Tokyo']));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+      const freshService = TestBed.inject(RecentSearchesService);
+      expect(freshService.getAll()()).toEqual(['Paris', 'Tokyo']);
+    });
+  });
+});

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,0 +1,13 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SettingsService {
+  private _unit = signal<'metric' | 'imperial'>('metric');
+  unit = this._unit.asReadonly();
+
+  toggle(): void {
+    this._unit.update((u) => (u === 'metric' ? 'imperial' : 'metric'));
+  }
+}

--- a/src/app/services/settings.spec.ts
+++ b/src/app/services/settings.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SettingsService } from './settings.service';
+
+describe('Settings', () => {
+  let service: SettingsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SettingsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Implements temperature unit toggle across the Result page. A new `SettingsService` holds the `metric` / `imperial` preference as a signal, and a standalone `TemperaturePipe` handles conversion and formatting (`22.0°C` / `71.6°F`). The toggle button on the Result page flips the unit instantly without triggering a new API call.

## Changes

- Created `SettingsService` with a private `signal<'metric' | 'imperial'>` and a `toggle()` method that flips between units
- Created standalone `TemperaturePipe` that converts Celsius to Fahrenheit and appends the correct symbol, rounding to 1 decimal place
- Added `unit = input.required<'metric' | 'imperial'>()` to `WeatherCard` and wired `TemperaturePipe` into its template
- Updated `ResultPage` to inject `SettingsService`, expose `unit` as a local signal alias, and pass it down to `<app-weather-card>`
- Added a toggle button to `result-page.html` that calls `settingsService.toggle()` and labels itself with the opposite unit
- Added humidity `%` and wind speed `km/h` units to `weather-card.html` (previously bare numbers)
- Added stub specs for `TemperaturePipe` and `SettingsService`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temperature unit selection with a visible toggle (metric ↔ imperial)
  * Weather card now shows formatted temperatures, wind speed and humidity with explicit unit labels
* **Tests**
  * Added/expanded unit tests for temperature and wind-speed formatting, settings, recent searches, and weather card display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->