### PR TITLE
Hide result panel on large screens

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -30,3 +30,9 @@
     display: none;
   }
 }
+
+@media (min-width: 900px) {
+  .result-panel.root {
+    display: none;
+  }
+}


### PR DESCRIPTION
## What
Hide the router outlet's `SearchPage` on desktop when at the root route `/`, so the search form only appears once (in the `<aside>`).

## Why
On desktop, `app.html` renders `SearchPage` in both a hardcoded `<aside>` and the router outlet, duplicating the form at `/`.

## How
- Added a `@media (min-width: 900px)` rule in `app.css` targeting `.result-panel.root { display: none }` — the existing `.root` class is already toggled by `isRootRoute` in `app.ts`, so no TS changes were needed.
- Mobile is unaffected: the `<aside>` is hidden below 900px, leaving the router outlet as the sole search entry point there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Result panel is now hidden on desktop screens (900px width and wider).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->