### PR TITLE
Add secondary color to material theme

### DIFF
--- a/src/material-theme.scss
+++ b/src/material-theme.scss
@@ -11,6 +11,7 @@ html {
     (
       color: (
         primary: mat.$azure-palette,
+        secondary: mat.$green-palette,
         tertiary: mat.$blue-palette,
       ),
       typography: Nunito,


### PR DESCRIPTION
## What
Added `secondary` palette to the Angular Material theme configuration in `src/material-theme.scss`.

## Why
Required to support distinct secondary tonal surface tokens (`--mat-sys-secondary-container`, `--mat-sys-on-secondary-container`) for downstream components.

## How
- Registered `mat.$green-palette` as the `secondary` color in the `mat.theme` mixin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application's material design color theme to include a secondary color palette, enhancing visual consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->