### PR TITLE
Enhance search page styling with expressive design elements

### DIFF
--- a/src/app/pages/search-page/search-page.css
+++ b/src/app/pages/search-page/search-page.css
@@ -34,3 +34,8 @@ form {
   color: var(--mat-sys-on-surface-variant);
   margin-bottom: 0.5rem;
 }
+
+.search-icon {
+  margin-left: 12px;
+  margin-right: 8px;
+}

--- a/src/app/pages/search-page/search-page.html
+++ b/src/app/pages/search-page/search-page.html
@@ -4,9 +4,9 @@
     <p class="description">Enter a city to get the weather and outfit recommendations.</p>
   </div>
   <form [formGroup]="form" (ngSubmit)="onSubmit()">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="expressive-input">
       <mat-label>City</mat-label>
-      <mat-icon matPrefix>search</mat-icon>
+      <mat-icon matPrefix class="search-icon">search</mat-icon>
       <input id="city" matInput formControlName="city" placeholder="Enter a city..." autofocus />
       <mat-error>Please enter a city name.</mat-error>
     </mat-form-field>
@@ -14,6 +14,7 @@
       mat-flat-button
       color="primary"
       type="submit"
+      class="expressive-button"
       [disabled]="cityControl.invalid && cityControl.touched"
     >
       Get Outfit

--- a/src/material-theme.scss
+++ b/src/material-theme.scss
@@ -16,6 +16,10 @@ html {
       ),
       typography: Nunito,
       density: 0,
+      shape: (
+        form-field: 28px,
+        button: 9999px,
+      ),
     )
   );
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,0 +1,28 @@
+$radius: 28px;
+
+// ── Expressive input ──────────────────────────────────────────────────────────
+// The MDC outlined text field renders its border as three separate spans:
+// __leading (left cap), __notch (label gap), __trailing (right cap).
+// border-radius must be applied to each piece individually.
+
+.expressive-input {
+  .mdc-notched-outline__leading {
+    border-radius: $radius 0 0 $radius !important;
+    min-width: $radius !important; // prevents the left cap from being too narrow
+  }
+
+  .mdc-notched-outline__trailing {
+    border-radius: 0 $radius $radius 0 !important;
+  }
+
+  // The notch holds the floating label — it must NOT be rounded
+  .mdc-notched-outline__notch {
+    border-radius: 0 !important;
+  }
+}
+
+// ── Expressive button ─────────────────────────────────────────────────────────
+.expressive-button.mat-mdc-button-base {
+  border-radius: 9999px !important;
+  min-height: 48px;
+}


### PR DESCRIPTION
## What
Adopt M3 Expressive shape guidelines for the search form input and the "Get Outfit" button.

## Why
To ensure visual consistency and better alignment with M3 design standards.

## How
- Added `expressive-input` and `expressive-button` classes to `src/app/pages/search-page/search-page.html` for targeted styling.
- Overrode MDC CSS variables in `src/styles.scss` to implement a 28px border-radius for the input and full-pill shape for the button.
- Adjusted the `search-icon` margins in `src/app/pages/search-page/search-page.css` to improve icon alignment.
