### PR TITLE
Style recent searches container

### DIFF
--- a/src/app/pages/search-page/search-page.css
+++ b/src/app/pages/search-page/search-page.css
@@ -36,3 +36,10 @@ form {
   color: var(--mat-sys-on-surface-variant);
   margin-bottom: 0.5rem;
 }
+
+.recent-searches-container {
+  background-color: var(--mat-sys-surface-container);
+  border-radius: 1rem;
+  padding: 1rem;
+  margin-top: 1rem;
+}

--- a/src/app/pages/search-page/search-page.html
+++ b/src/app/pages/search-page/search-page.html
@@ -20,7 +20,7 @@
     </button>
   </form>
   @if (recentCities().length) {
-  <div class="recent-searches">
+  <div class="recent-searches-container">
     <p class="recent-label">Recent searches</p>
     <mat-chip-set>
       @for (city of recentCities(); track city) {


### PR DESCRIPTION
## What
Grouped the recent search chips into a tonal container on the search page.

## Why
To reduce visual clutter and improve the grouping of recent searches.

## How
- Wrapped the existing `<mat-chip-set>` in a new `div` with class `.recent-searches-container` in `src/app/pages/search-page/search-page.html`.
- Added styles for `.recent-searches-container` in `src/app/pages/search-page/search-page.css` using `var(--mat-sys-surface-container)`, `border-radius: 1rem`, and `padding: 1rem`.
