### PR TITLE
Add tonal button style to app header

### DIFF
--- a/src/app/components/app-header/app-header.css
+++ b/src/app/components/app-header/app-header.css
@@ -1,3 +1,14 @@
 .spacer {
   flex: 1 1 auto;
 }
+
+.tonal-button {
+  background-color: var(--mat-sys-secondary-container);
+  color: var(--mat-sys-on-secondary-container);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/app/components/app-header/app-header.html
+++ b/src/app/components/app-header/app-header.html
@@ -1,7 +1,12 @@
 <mat-toolbar color="primary">
   <span>Mausam</span>
   <span class="spacer"></span>
-  <button mat-icon-button (click)="settingsService.toggleDarkMode()" aria-label="Toggle dark mode">
+  <button
+    mat-icon-button
+    class="tonal-button"
+    (click)="settingsService.toggleDarkMode()"
+    aria-label="Toggle dark mode"
+  >
     <mat-icon>{{ settingsService.isDarkMode() ? 'light_mode' : 'dark_mode' }}</mat-icon>
   </button>
 </mat-toolbar>


### PR DESCRIPTION
## What
Upgraded the dark-mode toggle button in `AppHeader` from a ghost button to a filled tonal icon button.

## Why
To improve scannability on the toolbar and ensure the button doesn't compete with the primary CTA.

## How
- Added the `tonal-button` class to the button element in `src/app/components/app-header/app-header.html`.
- Defined the `tonal-button` style in `src/app/components/app-header/app-header.css` to use `var(--mat-sys-secondary-container)` for the background and ensure a 40x40px hit target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added new tonal button styling to the app header featuring a circular design with Material Design colors and centered alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->