### PR TITLE
Add container to weather card illustration

### DIFF
--- a/src/app/components/weather-card/weather-card.css
+++ b/src/app/components/weather-card/weather-card.css
@@ -13,6 +13,19 @@ mat-card {
   padding: 2rem 0;
 }
 
+.illustration-container {
+  background-color: var(--mat-sys-secondary-container);
+  border-radius: 50%;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 112px;
+  height: 112px;
+  box-sizing: border-box;
+}
+
 .illustration {
   width: 80px;
   height: 80px;

--- a/src/app/components/weather-card/weather-card.html
+++ b/src/app/components/weather-card/weather-card.html
@@ -1,11 +1,13 @@
 <div class="container">
   <mat-card class="stats" appearance="outlined">
     <div class="card-main">
-      <img
-        class="illustration"
-        [src]="'assets/illustrations/' + weather().illustrationKey + '.svg'"
-        [alt]="weather().condition + ' weather illustration'"
-      />
+      <div class="illustration-container">
+        <img
+          class="illustration"
+          [src]="'assets/illustrations/' + weather().illustrationKey + '.svg'"
+          [alt]="weather().condition + ' weather illustration'"
+        />
+      </div>
       <mat-card-header>
         <mat-card-title>{{ weather().temperature | temperature: unit() }}</mat-card-title>
         <mat-card-subtitle>{{ weather().condition }}</mat-card-subtitle>


### PR DESCRIPTION
## What
Enclose the weather illustration in a circular `secondary-container` bubble.

## Why
Improves UI to meet M3 Expressive's contrasting shape principle and creates a clear focal point.

## How
- Wrapped the `<img>` tag in `src/app/components/weather-card/weather-card.html` with a new `div` using the `illustration-container` class.
- Added CSS styles in `src/app/components/weather-card/weather-card.css` to `illustration-container` to apply the `secondary-container` background, `50%` border-radius, and ensure correct sizing and alignment.
