### PR TITLE
Update outfit card to filled tonal appearance

### DIFF
--- a/src/app/components/outfit-card/outfit-card.css
+++ b/src/app/components/outfit-card/outfit-card.css
@@ -3,3 +3,8 @@
   border-radius: 0.75em;
   padding: 1.5em;
 }
+
+.filled-tonal-card {
+  background-color: var(--mat-sys-surface-container-high);
+  border: none;
+}

--- a/src/app/components/outfit-card/outfit-card.html
+++ b/src/app/components/outfit-card/outfit-card.html
@@ -1,4 +1,4 @@
-<mat-card appearance="outlined">
+<mat-card class="filled-tonal-card">
   <mat-card-header>
     <mat-card-title>What to wear</mat-card-title>
   </mat-card-header>


### PR DESCRIPTION
## What
Updated the `OutfitCard` component to use a filled tonal surface style instead of an outlined style.

## Why
To visually differentiate the `OutfitCard` from the `WeatherCard` and reinforce M3 Expressive containment design principles.

## How
- Removed `appearance="outlined"` from the `<mat-card>` in `mausam\src\app\components\outfit-card\outfit-card.html`.
- Applied a new `filled-tonal-card` CSS class to the `<mat-card>`.
- Defined `filled-tonal-card` in `mausam\src\app\components\outfit-card\outfit-card.css` to use `var(--mat-sys-surface-container-high)` and remove the border.
