### PR TITLE
Style unit toggle button group on results page

### DIFF
--- a/src/app/pages/result-page/result-page.css
+++ b/src/app/pages/result-page/result-page.css
@@ -56,3 +56,19 @@
   margin: 0;
   text-align: center;
 }
+
+.unit-toggle {
+  background-color: var(--mat-sys-primary-container);
+  border-radius: 999px;
+  border: none;
+  overflow: hidden;
+  display: inline-flex;
+}
+
+::ng-deep .unit-toggle {
+  --mat-button-toggle-label-text-color: var(--mat-sys-on-primary-container);
+  --mat-button-toggle-selected-state-text-color: var(--mat-sys-on-primary);
+  --mat-button-toggle-selected-state-background-color: var(--mat-sys-primary);
+
+  background-color: var(--mat-sys-primary-container);
+}

--- a/src/app/pages/result-page/result-page.html
+++ b/src/app/pages/result-page/result-page.html
@@ -11,7 +11,11 @@
     <span class="city-label">Weather in</span>
     <h1 class="city-name">{{ cityName() }}</h1>
   </div>
-  <mat-button-toggle-group [value]="unit()" (change)="settingsService.setUnit($event.value)">
+  <mat-button-toggle-group
+    class="unit-toggle"
+    [value]="unit()"
+    (change)="settingsService.setUnit($event.value)"
+  >
     <mat-button-toggle value="metric">°C · km/h</mat-button-toggle>
     <mat-button-toggle value="imperial">°F · mph</mat-button-toggle>
   </mat-button-toggle-group>


### PR DESCRIPTION
## What
Styled the °C/°F unit selector component to adopt a pill shape with a primary-container tonal background.

## Why
To improve visual hierarchy, ensure better accessibility through color contrast, and anchor the selector visually to the cards grid.

## How
- Added the `unit-toggle` class to the `mat-button-toggle-group` in `result-page.html`.
- Defined styles in `result-page.css` using `::ng-deep` and Angular Material CSS custom properties to ensure consistent styling and proper contrast for both text and icons.
