### PR TITLE
Update IP location API endpoint

### DIFF
--- a/src/app/services/ip-location.service.ts
+++ b/src/app/services/ip-location.service.ts
@@ -8,7 +8,7 @@ export class IpLocationService {
   private readonly router = inject(Router);
 
   detect(): void {
-    this.http.get<{ city: string; status: string }>('https://ip-api.com/json').subscribe({
+    this.http.get<{ city: string; status: string }>('https://ipapi.co/json').subscribe({
       next: ({ status, city }) => {
         if (status === 'success' && city) {
           this.router.navigate(['/outfit', city]);


### PR DESCRIPTION
## What
Updated the API endpoint URL for IP geolocation in `IpLocationService`.

## Why
The previous service endpoint required an update to ensure continued functionality.

## How
- Changed the target URL in `src/app/services/ip-location.service.ts` from `https://ip-api.com/json` to `https://ipapi.co/json`.
